### PR TITLE
Added warning for the color theme setting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
 2. Open sidebery settings > Styles editor
 3. Paste the css in the css editor
 
+⚠️ Make sure that the *Appearance* > *Color Theme* setting is set to `auto` in oder for the theme to apply properly.
+
 ## 💝 Thanks to
 
 - [thismoon](https://github.com/thismoon)


### PR DESCRIPTION
If Sidebery's Color Scheme setting is set to `light` or `dark`, the catppuccin color scheme will not apply. 
Diagnosed on Firefox 109 & sidebery 4.10.2.

This small warning will help users diagnose this specific behavior.